### PR TITLE
Fix: Annotate fun calls on code with bad syntax

### DIFF
--- a/R/annotate_fun_calls.R
+++ b/R/annotate_fun_calls.R
@@ -31,6 +31,13 @@ annotate_fun_calls <- function(string_og) {
   }
 
   fun_calls <- get_function_calls(string_og) # get script's function calls.
+  if (length(fun_calls) == 0) {
+    # If we couldn't parse any function call then it means there are syntax errors.
+    stop(
+      "No code could be parsed, please make sure your R code has no syntax errors.",
+      call. = FALSE
+    )
+  }
 
   # build annotations
   if (all(!grepl("p_load", out_tb$call))) { # no pacman calls


### PR DESCRIPTION
I found a bug with `annotate_fun_calls`, if the R code has wrong syntax (unparsable code), then the annotated adds "# No used functions found" instead of avoiding this incorrect annotation.

In this file, `select` is imported from `{dplyr}`, but the file syntax is incorrect because of the `if else`,
```r
library(dplyr)
select(mtcars[1, ], mpg)

if else
```

and it gets this incorrect annotation
```r
library(dplyr) # No used functions found
select(mtcars[1, ], mpg)

if else
```

I think we should show an error instead of returning this wrong annotation.
Ideally, we should ignore the unparsable code, but I don't have an idea on how to build this annotator without parsing the script.